### PR TITLE
Add build targets for gen3/5/all

### DIFF
--- a/include/config/general.h
+++ b/include/config/general.h
@@ -53,11 +53,6 @@
 #define POKEMON_EXPANSION
 #define ITEM_EXPANSION
 
-// ### SWITCH Generations for different game version! ###
-//#define PIT_GEN_3_MODE
-//#define PIT_GEN_5_MODE
-#define PIT_GEN_9_MODE
-
 // Generation constants used in configs to define behavior
 #define GEN_1 0
 #define GEN_2 1

--- a/src/pit_arena.c
+++ b/src/pit_arena.c
@@ -2156,7 +2156,7 @@ static const struct RandomBossEncounters sRandomBossEncounterArray[] = {
                             .heldItem = ITEM_CHOICE_BAND,
                             .ability = 0,
                             .nature = NATURE_JOLLY,
-                            .moves = {MOVE_DOUBLE-EDGE, MOVE_SHADOW_BALL, MOVE_HYPER_BEAM, MOVE_EARTHQUAKE}
+                            .moves = {MOVE_DOUBLE_EDGE, MOVE_SHADOW_BALL, MOVE_HYPER_BEAM, MOVE_EARTHQUAKE}
                         },
 #elif (GEN_LATEST == GEN_5)
         .trainerAce =   {
@@ -2167,7 +2167,7 @@ static const struct RandomBossEncounters sRandomBossEncounterArray[] = {
                             .heldItem = ITEM_CHOICE_BAND,
                             .ability = 0,
                             .nature = NATURE_JOLLY,
-                            .moves = {MOVE_DOUBLE-EDGE, MOVE_EARTHQUAKE, MOVE_NIGHT_SLASH, MOVE_ROCK_SLIDE}
+                            .moves = {MOVE_DOUBLE_EDGE, MOVE_EARTHQUAKE, MOVE_NIGHT_SLASH, MOVE_ROCK_SLIDE}
                         },
 #else
         .trainerAce =   {
@@ -2446,7 +2446,7 @@ static const struct RandomBossEncounters sRandomBossEncounterArray[] = {
                             .heldItem = ITEM_CHOICE_BAND,
                             .ability = 0,
                             .nature = NATURE_ADAMANT,
-                            .moves = {MOVE_METEOR_MASH, MOVE_EARTHQUAKE, MOVE_DOUBLE-EDGE, MOVE_ROCK_SLIDE}
+                            .moves = {MOVE_METEOR_MASH, MOVE_EARTHQUAKE, MOVE_DOUBLE_EDGE, MOVE_ROCK_SLIDE}
                         },
 #elif (GEN_LATEST == GEN_5)
         .trainerAce =   {


### PR DESCRIPTION
Adds build targets for gen3, gen5, and all 3 versions.
`make gen3` = make the gen3 version
`make gen5` = make the gen5 version
`make` = make the gen9 version
`make pit` = make all three versions

Also fixes a couple typos preventing the gen3/5 versions from building