### PR TITLE
Set assembler directives for gen modes in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,10 +202,13 @@ endif
 # set pit gen preproc defines
 ifeq ($(PIT_GEN_3_MODE), 1)
   override CPPFLAGS += -DPIT_GEN_3_MODE=$(PIT_GEN_3_MODE)
+  override ASFLAGS += --defsym PIT_GEN_3_MODE=$(PIT_GEN_3_MODE)
 else ifeq ($(PIT_GEN_5_MODE), 1)
   override CPPFLAGS += -DPIT_GEN_5_MODE=$(PIT_GEN_5_MODE)
+  override ASFLAGS += --defsym PIT_GEN_5_MODE=$(PIT_GEN_5_MODE)
 else
   override CPPFLAGS += -DPIT_GEN_9_MODE=$(PIT_GEN_9_MODE)
+  override ASFLAGS += --defsym PIT_GEN_9_MODE=$(PIT_GEN_9_MODE)
 endif
 
 # Variable filled out in other make files

--- a/data/maps/BattleFrontier_Lounge7/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge7/scripts.inc
@@ -127,7 +127,7 @@ BattleFrontier_Lounge7_EventScript_SwordsDance::
 
 BattleFrontier_Lounge7_EventScript_SetUpTutorMovesForLearnsets::
 	setvar VAR_0x8008, 48
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 	setvar VAR_0x8005, MOVE_FRENZY_PLANT
 	setvar VAR_0x8005, MOVE_BLAST_BURN
 	setvar VAR_0x8005, MOVE_HYDRO_CANNON
@@ -140,7 +140,7 @@ BattleFrontier_Lounge7_EventScript_SetUpTutorMovesForLearnsets::
 	setvar VAR_0x8005, MOVE_HYDRO_CANNON
 	setvar VAR_0x8005, MOVE_RELIC_SONG
 	setvar VAR_0x8005, MOVE_SECRET_SWORD
-#endif
+.endif
 	goto BattleFrontier_Lounge7_EventScript_ConfirmMoveSelection
 	end
 

--- a/data/maps/PitEntrance/scripts.inc
+++ b/data/maps/PitEntrance/scripts.inc
@@ -71,11 +71,11 @@ PitEntrance_Warp::
 	goto_if_eq VAR_RESULT, 0, PitEntrance_Warp_SkipShinyDust
 	additem ITEM_SHINY_DUST, 1
 PitEntrance_Warp_SkipShinyDust::
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 	additem ITEM_MEGA_RING, 1
 	@additem ITEM_TERA_ORB, 1
 	additem ITEM_Z_POWER_RING, 1
-#endif
+.endif
 	additem ITEM_EXP_SHARE, 1
 	setflag FLAG_SYS_POKEMON_GET
 	warpteleport MAP_PIT_ARENA, 9, 7

--- a/data/scripts/pit_item_shop.inc
+++ b/data/scripts/pit_item_shop.inc
@@ -5,32 +5,32 @@ PitShop_ShopNPC::
 	setvar VAR_TEMP_9, 0
 PitShop_ShopNPCHook::
 	message PitShop_ShopNPC_Text
-#ifdef PIT_GEN_3_MODE
+.ifdef PIT_GEN_3_MODE
 	goto_if_unset FLAG_STAT_CHANGER, PitShop_ShopNPCHook_Gen3IVs
 	dynmultichoice 17, 1, 0, 5, VAR_TEMP_9, DYN_MULTICHOICE_CB_NONE, PitShop_ShopNPC_Option0, PitShop_ShopNPC_Option1, PitShop_ShopNPC_OptionVitamin, PitShop_ShopNPC_Option7, PitShop_ShopNPC_Option8
-#elif defined PIT_GEN_5_MODE
+.elseif PIT_GEN_5_MODE == 1
 	goto_if_unset FLAG_STAT_CHANGER, PitShop_ShopNPCHook_Gen5IVs
 	dynmultichoice 17, 1, 0, 5, VAR_TEMP_9, DYN_MULTICHOICE_CB_NONE, PitShop_ShopNPC_Option0, PitShop_ShopNPC_Option1, PitShop_ShopNPC_OptionVitamin, PitShop_ShopNPC_Option4, PitShop_ShopNPC_Option6, PitShop_ShopNPC_Option7, PitShop_ShopNPC_Option8
-#else
+.else
 	goto_if_unset FLAG_STAT_CHANGER, PitShop_ShopNPCHook_Gen9IVs
 	dynmultichoice 17, 1, 0, 5, VAR_TEMP_9, DYN_MULTICHOICE_CB_NONE, PitShop_ShopNPC_Option0, PitShop_ShopNPC_Option0_100, PitShop_ShopNPC_Option0_200, PitShop_ShopNPC_Option1, PitShop_ShopNPC_OptionVitamin, PitShop_ShopNPC_Option2, PitShop_ShopNPC_Option3, PitShop_ShopNPC_Option4, PitShop_ShopNPC_Option5, PitShop_ShopNPC_Option6, PitShop_ShopNPC_Option7, PitShop_ShopNPC_Option8
-#endif
+.endif
 	closemessage
 	setflag FLAG_BUY_FROM_MART
 	copyvar VAR_TEMP_9, VAR_RESULT
-#ifdef PIT_GEN_3_MODE
+.ifdef PIT_GEN_3_MODE
 	goto_if_eq VAR_RESULT, 0, PitArena_MartScript_TMs
 	goto_if_eq VAR_RESULT, 1, PitArena_MartScript_EvoItems
 	goto_if_eq VAR_RESULT, 2, PitArena_MartScript_Vitamins
 	goto_if_eq VAR_RESULT, 3, PitArena_MartScript_Sell
-#elif defined PIT_GEN_5_MODE
+.elseif PIT_GEN_5_MODE == 1
 	goto_if_eq VAR_RESULT, 0, PitArena_MartScript_TMs
 	goto_if_eq VAR_RESULT, 1, PitArena_MartScript_EvoItems
 	goto_if_eq VAR_RESULT, 2, PitArena_MartScript_Vitamins
 	goto_if_eq VAR_RESULT, 3, PitArena_MartScript_Gems
 	goto_if_eq VAR_RESULT, 4, PitArena_MartScript_FormItems
 	goto_if_eq VAR_RESULT, 5, PitArena_MartScript_Sell
-#else
+.else
 	goto_if_eq VAR_RESULT, 0, PitArena_MartScript_TMs
 	goto_if_eq VAR_RESULT, 1, PitArena_MartScript_TMs_100
 	goto_if_eq VAR_RESULT, 2, PitArena_MartScript_TMs_200
@@ -42,7 +42,7 @@ PitShop_ShopNPCHook::
 	goto_if_eq VAR_RESULT, 8, PitArena_MartScript_ZCrystals
 	goto_if_eq VAR_RESULT, 9, PitArena_MartScript_FormItems
 	goto_if_eq VAR_RESULT, 10, PitArena_MartScript_Sell
-#endif
+.endif
 EndOfMartScript::
 	clearflag FLAG_SELL_FROM_MART
 	clearflag FLAG_BUY_FROM_MART
@@ -230,11 +230,11 @@ PitArena_MartScript_EditIVs_Execute::
 
 
 PitShop_ShopNPC_Option0:
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 	.string "TMs A-F$"
-#else
+.else
 	.string "TMs    $"
-#endif
+.endif
 PitShop_ShopNPC_Option0_100:
 	.string "TMs G-R$"
 PitShop_ShopNPC_Option0_200:
@@ -293,14 +293,14 @@ PitArena_Mart_Vitamins:
 	.2byte ITEM_HP_UP
 	.2byte ITEM_PP_UP
 	.2byte ITEM_PP_MAX
-#ifndef PIT_GEN_3_MODE
+.ifndef PIT_GEN_3_MODE
 	.2byte ITEM_HEALTH_FEATHER
 	.2byte ITEM_MUSCLE_FEATHER
 	.2byte ITEM_RESIST_FEATHER
 	.2byte ITEM_GENIUS_FEATHER
 	.2byte ITEM_CLEVER_FEATHER
 	.2byte ITEM_SWIFT_FEATHER
-#endif
+.endif
 	.2byte ITEM_NONE
 	release
 	end
@@ -322,23 +322,23 @@ PitArena_Mart_Vitamins_HARD:
 	.2byte ITEM_HP_UP
 	.2byte ITEM_PP_UP
 	.2byte ITEM_PP_MAX
-#ifndef PIT_GEN_3_MODE
+.ifndef PIT_GEN_3_MODE
 	.2byte ITEM_HEALTH_FEATHER
 	.2byte ITEM_MUSCLE_FEATHER
 	.2byte ITEM_RESIST_FEATHER
 	.2byte ITEM_GENIUS_FEATHER
 	.2byte ITEM_CLEVER_FEATHER
 	.2byte ITEM_SWIFT_FEATHER
-#endif
+.endif
 	.2byte ITEM_NONE
 	release
 	end
 
 	.align 2
 PitArena_Mart_EvoItems:
-#ifdef PIT_GEN_3_MODE
+.ifdef PIT_GEN_3_MODE
 	.2byte  ITEM_METEORITE
-#endif
+.endif
 	.2byte ITEM_EVERSTONE
     .2byte ITEM_FIRE_STONE
     .2byte ITEM_WATER_STONE
@@ -354,7 +354,7 @@ PitArena_Mart_EvoItems:
     .2byte ITEM_PRISM_SCALE
     .2byte ITEM_DEEP_SEA_TOOTH
     .2byte ITEM_DEEP_SEA_SCALE
-#ifndef PIT_GEN_3_MODE
+.ifndef PIT_GEN_3_MODE
 	.2byte ITEM_DAWN_STONE
     .2byte ITEM_DUSK_STONE
     .2byte ITEM_SHINY_STONE
@@ -366,8 +366,8 @@ PitArena_Mart_EvoItems:
     .2byte ITEM_RAZOR_FANG
     .2byte ITEM_DUBIOUS_DISC
     .2byte ITEM_REAPER_CLOTH
-#endif
-#ifdef PIT_GEN_9_MODE
+.endif
+.ifdef PIT_GEN_9_MODE
     .2byte ITEM_ICE_STONE
     .2byte ITEM_WHIPPED_DREAM
     .2byte ITEM_SACHET
@@ -396,7 +396,7 @@ PitArena_Mart_EvoItems:
     .2byte ITEM_FLOWER_SWEET
     .2byte ITEM_STAR_SWEET
     .2byte ITEM_RIBBON_SWEET
-#endif
+.endif
 	.2byte ITEM_NONE
 	release
 	end
@@ -558,7 +558,7 @@ PitArena_Mart_FormItems:
 	.2byte  ITEM_GRISEOUS_CORE
 	.2byte  ITEM_ROTOM_CATALOG
 	.2byte  ITEM_REVEAL_GLASS
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 	.2byte  ITEM_PRISON_BOTTLE
 	.2byte  ITEM_ADAMANT_CRYSTAL
 	.2byte  ITEM_LUSTROUS_GLOBE
@@ -567,7 +567,7 @@ PitArena_Mart_FormItems:
     .2byte  ITEM_RUSTED_SWORD
     .2byte  ITEM_RUSTED_SHIELD
     .2byte  ITEM_REINS_OF_UNITY
-#endif
+.endif
     .2byte  ITEM_DOUSE_DRIVE
     .2byte  ITEM_SHOCK_DRIVE
     .2byte  ITEM_BURN_DRIVE
@@ -589,7 +589,7 @@ PitArena_Mart_FormItems:
     .2byte  ITEM_DREAD_PLATE
     .2byte  ITEM_IRON_PLATE
     .2byte  ITEM_PIXIE_PLATE
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 	.2byte  ITEM_YELLOW_NECTAR
     .2byte  ITEM_PINK_NECTAR
     .2byte  ITEM_PURPLE_NECTAR
@@ -610,14 +610,14 @@ PitArena_Mart_FormItems:
     .2byte  ITEM_DARK_MEMORY
     .2byte  ITEM_STEEL_MEMORY
     .2byte  ITEM_FAIRY_MEMORY
-#endif
+.endif
 	.2byte ITEM_NONE
     release
 	end
 
  	.align 2
 PitArena_Mart_TMs:
-#ifdef PIT_GEN_3_MODE
+.ifdef PIT_GEN_3_MODE
 	.2byte ITEM_TM40
 	.2byte ITEM_TM45
 	.2byte ITEM_TM14
@@ -698,8 +698,8 @@ PitArena_Mart_TMs:
 	.2byte ITEM_TM41
 	.2byte ITEM_TM06
 	.2byte ITEM_TM03
-#endif
-#ifdef PIT_GEN_5_MODE
+.endif
+.ifdef PIT_GEN_5_MODE
 	.2byte ITEM_TM62
 	.2byte ITEM_TM40
 	.2byte ITEM_TM51
@@ -800,8 +800,8 @@ PitArena_Mart_TMs:
 	.2byte ITEM_TM61
 	.2byte ITEM_TM83
 	.2byte ITEM_TM81
-#endif
-#ifdef PIT_GEN_9_MODE
+.endif
+.ifdef PIT_GEN_9_MODE
 	.2byte ITEM_TM13
 	.2byte ITEM_TM14
 	.2byte ITEM_TM27
@@ -882,8 +882,8 @@ PitArena_Mart_TMs:
 	.2byte ITEM_TM62
 	.2byte ITEM_TM155
 	.2byte ITEM_TM217
-#endif
-#ifndef PIT_GEN_9_MODE
+.endif
+.ifndef PIT_GEN_9_MODE
 	.2byte ITEM_HM01
 	.2byte ITEM_HM02
 	.2byte ITEM_HM03
@@ -892,7 +892,7 @@ PitArena_Mart_TMs:
 	.2byte ITEM_HM06
 	.2byte ITEM_HM07
 	.2byte ITEM_HM08
-#endif
+.endif
 	.2byte ITEM_NONE
     release
 	end

--- a/data/scripts/pit_mon_encounters.inc
+++ b/data/scripts/pit_mon_encounters.inc
@@ -79,13 +79,13 @@ PitEncounter_NuggetDrop_alreadyUsed::
 	msgbox PitEncounter_NuggetDrop_alreadyUsed_Text, MSGBOX_DEFAULT
 	release
 	end
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 PitEncounter_NuggetDrop_alreadyUsed_Text:
 	.string "Gholdengo$"
-#else
+.else
 PitEncounter_NuggetDrop_alreadyUsed_Text:
 	.string "Sableye$"
-#endif
+.endif
 
 PitEncounter_WonderTrade_alreadyUsed::
 	faceplayer
@@ -269,13 +269,13 @@ PitEncounter_NuggetDrop::
 	call PitEncounter_Common_AfterUse
 	release
 	end
-#ifdef PIT_GEN_9_MODE
+.ifdef PIT_GEN_9_MODE
 PitEncounter_NuggetDrop_Text:
 	.string "Gholdengo just lost a Nugget.\nQuick, take it!$"
-#else
+.else
 PitEncounter_NuggetDrop_Text:
 	.string "Sableye just lost a Nugget.\nQuick, take it!$"
-#endif
+.endif
 
 @ Wonder Trade NPC
 PitEncounter_WonderTrade::

--- a/data/scripts/pit_stop.inc
+++ b/data/scripts/pit_stop.inc
@@ -17,17 +17,17 @@ PitTutor_MoveRelearner::
 	lockall
 	faceplayer
 	showmoneybox 12, 11
-#ifndef PIT_GEN_9_MODE
+.ifndef PIT_GEN_9_MODE
 	dynmultichoice 17, 1, 0, 5, 0, DYN_MULTICHOICE_CB_NONE, PitTutor_MoveRelearnerText, PitArena_EggMovesText, PitArena_PreEvoMovesText, PitArena_TutorMovesText, PitShop_ShopNPC_Option8
-#else
+.else
 	dynmultichoice 17, 1, 0, 5, 0, DYN_MULTICHOICE_CB_NONE, PitTutor_MoveRelearnerText, PitArena_EggMovesText, PitArena_PreEvoMovesText, PitShop_ShopNPC_Option8
-#endif	
+.endif	
 	goto_if_eq VAR_RESULT, 0, PitTutor_MartNPCMoveRelearner
 	goto_if_eq VAR_RESULT, 1, PitTutor_MartNPCMoveTutorEggMoves
 	goto_if_eq VAR_RESULT, 2, PitTutor_MartNPCMoveTutorPreEvoMoves
-#ifndef PIT_GEN_9_MODE
+.ifndef PIT_GEN_9_MODE
 	goto_if_eq VAR_RESULT, 3, PitTutor_MartNPCMoveTutorTutorMoves
-#endif
+.endif
 EndOfRelearnerScript::
 	hidemoneybox
 	release


### PR DESCRIPTION
Fixes preproc directives for gen 3/5/9 modes not working in .inc files